### PR TITLE
fix "*/**" copy res without sub file.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,10 +22,10 @@ gulp.task('clean', function (callback) {
 gulp.task('copy', function () {
     gulp.src(['./src/browser.js', './src/app.config.js', './src/*.html'])
         .pipe(gulp.dest('./app'));
-    gulp.src(['./src/assets/*/**'])
+    gulp.src(['./src/assets/*', './src/assets/*/**'])
         .pipe(gulp.dest('./app/assets'));
     gulp.src(['./package.json']).pipe(gulp.dest('./app'));
-    gulp.src(['./node_modules/electron-sudo/*/**'])
+    gulp.src(['./node_modules/electron-sudo/*', './node_modules/electron-sudo/*/**'])
         .pipe(gulp.dest('./app/node_modules/electron-sudo'));
 });
 


### PR DESCRIPTION
```
fix "*/**" copy res without sub file.
if "/**" -> run 'gulp' throw 'Error: EISDIR: illegal operation on a directory, read at Error (native)'.
if "*/**" -> copy res without sub file.(I had this problem(Empty window after 'npm start') before is because of it)
```